### PR TITLE
Compilation error for `wasm32-unknown-unknown` target -> removed libc dependency and used core::ffi c-types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,3 @@ repository = "https://github.com/blas-lapack-rs/cblas-sys"
 readme = "README.md"
 categories = ["external-ffi-bindings", "science"]
 keywords = ["linear-algebra"]
-
-[dependencies]
-libc = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,15 +8,15 @@
 #![allow(non_camel_case_types)]
 #![no_std]
 
-use libc::{c_char, c_double, c_float, c_int};
+use core::ffi::{c_char, c_double, c_float, c_int};
 
 /// A complex number with 64-bit parts.
 #[allow(bad_style)]
-pub type c_double_complex = [libc::c_double; 2];
+pub type c_double_complex = [c_double; 2];
 
 /// A complex number with 32-bit parts.
 #[allow(bad_style)]
-pub type c_float_complex = [libc::c_float; 2];
+pub type c_float_complex = [c_float; 2];
 
 pub type CBLAS_INDEX = c_int;
 


### PR DESCRIPTION
I was trying to compile a local project with `cblas-sys` as a dependency to the target `wasm32-unknown-unknown` using `wasm-pack`. I got a compilation error stating that the used aliases for the c-types are not found:
```sh
error[E0432]: unresolved imports `libc::c_char`, `libc::c_double`, `libc::c_float`, `libc::c_int`
  --> $HOME/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cblas-sys-0.2.0/src/lib.rs:11:12
   |
11 | use libc::{c_char, c_double, c_float, c_int};
   |            ^^^^^^  ^^^^^^^^  ^^^^^^^  ^^^^^ no `c_int` in the root
   |            |       |         |
   |            |       |         no `c_float` in the root
   |            |       no `c_double` in the root
   |            no `c_char` in the root
   |
   = help: consider importing this type alias instead:
           core::ffi::c_char
   = help: consider importing this type alias instead:
           core::ffi::c_double
   = help: consider importing this type alias instead:
           core::ffi::c_float
   = help: consider importing this type alias instead:
           core::ffi::c_int
```

I followed the suggestion to exchange the type aliases and use the ones in the `core::ffi` module. Using these types, `cblas-sys` compiles without errors to the `wasm32-unknown-unknown` target.